### PR TITLE
Fix RJMP, RCALL statements and add HEX creation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ATmega328Compiler
 *.hex
 *.elf
 *.map
+*.hex
 *.o
 CTestTestfile.cmake
 Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ATmega328Compiler
 *.o
 CTestTestfile.cmake
 Makefile
+/build

--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,7 @@ NOP
 
 Compilation Command:
 ```
-./compiler input.asm output.bin
+./compiler bin input.asm output.bin
 ```
 
 ## Examples
@@ -110,7 +110,7 @@ DELAY_LOOP:
 Compile the Assembly Code: Use the compiler you've written to convert blink.asm into a binary file.
 
 ```
-./compiler blink.asm blink.bin
+./compiler bin blink.asm blink.bin
 ```
 
 Upload to Arduino:
@@ -160,14 +160,9 @@ Compile the Program:
 g++ -o atmega328_compiler atmega328_compiler.cpp
 ```
 
-Run the Tests: Use the --test flag to run the unit tests:
-```
-./atmega328_compiler --test
-```
-
 Regular Compilation: To compile an assembly file to machine code, use:
 
 ```
-./atmega328_compiler <input.asm> <output.bin>
+./atmega328_compiler <hex/bin> <input.asm> <output.bin>
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -83,26 +83,15 @@ This will create a loop that continually adds R16 to R17.
 Save the following code in a file named blink.asm:
 
 ```
-; Define the LED pin and delay
-LDI R16, 0x20       ; Set R16 to 0x20 (Pin 5, PORTB)
-OUT 0x24, R16       ; Set DDRB to configure Pin 5 as output
+START:
+    LDI R16, 0x20       ; Set bit 5 (0b00100000)
+    OUT 0x24, R16       ; DDRB - configure Pin 5 as output
 
 LOOP:
-    OUT 0x25, R16   ; Turn LED on (PORTB)
-    CALL DELAY      ; Call delay subroutine
-    OUT 0x25, R0    ; Turn LED off (PORTB)
-    CALL DELAY      ; Call delay subroutine
-    JMP LOOP        ; Repeat the loop
-
-DELAY:
-    LDI R18, 0xFF   ; Outer loop counter
-    LDI R19, 0xFF   ; Inner loop counter
-DELAY_LOOP:
-    DEC R19         ; Decrement inner loop counter
-    BRNE DELAY_LOOP ; Branch if not zero
-    DEC R18         ; Decrement outer loop counter
-    BRNE DELAY_LOOP ; Branch if not zero
-    RET             ; Return from subroutine
+    OUT 0x25, R16       ; PORTB - LED ON
+    CLR R17             ; Clear R17
+    OUT 0x25, R17       ; PORTB - LED OFF
+    RJMP LOOP           ; Jump back to LOOP
 ```
 
 ***Steps to Assemble and Run the Code***
@@ -110,7 +99,7 @@ DELAY_LOOP:
 Compile the Assembly Code: Use the compiler you've written to convert blink.asm into a binary file.
 
 ```
-./compiler bin blink.asm blink.bin
+./compiler hex blink.asm blink.hex
 ```
 
 Upload to Arduino:
@@ -120,7 +109,28 @@ Upload to Arduino:
 * Use the following command to upload the binary file:
 
 ```
-avrdude -c arduino -p m328p -P /dev/ttyUSB0 -b 115200 -U flash:w:blink.bin
+avrdude -c arduino -p m328p -P /dev/ttyUSB0 -b 115200 -U flash:w:blink.hex
+
+>> avrdude: AVR device initialized and ready to accept instructions
+>> avrdude: device signature = 0x1e950f (probably m328p)
+>> avrdude: Note: flash memory has been specified, an erase cycle will be performed.
+>>          To disable this feature, specify the -D option.
+>> avrdude: erasing chip
+>> avrdude: reading input file blink.hex for flash
+>>          with 22 bytes in 1 section within [0, 0x15]
+>>          using 1 page and 106 pad bytes
+>> avrdude: writing 22 bytes flash ...
+>> 
+>> Writing | ################################################## | 100% 0.04 s
+>> 
+>> avrdude: 22 bytes of flash written
+>> avrdude: verifying flash memory against blink.hex
+>> 
+>> Reading | ################################################## | 100% 0.02 s
+>> 
+>> avrdude: 22 bytes of flash verified
+>> 
+>> avrdude done.  Thank you.
 ```
 ***Info:** *Replace /dev/ttyUSB0 with the correct port on your system.*
 

--- a/examples/blink.asm
+++ b/examples/blink.asm
@@ -6,7 +6,7 @@
 ; Author: Swen Kalski
 
 ; Initialize LED pin
-     LDI R16, 0x20       ; Set bit 5 (0b00100000)
+    LDI R16, 0x20       ; Set bit 5 (0b00100000)
     OUT 0x24, R16       ; DDRB - configure Pin 5 as output
     CLR R17             ; Clear R17 for LED off state
 
@@ -15,19 +15,19 @@ MAIN:
     RCALL DELAY         ; Wait 1 second
     OUT 0x25, R17       ; PORTB - LED OFF
     RCALL DELAY         ; Wait 1 second
-    RJMP MAIN          ; Repeat forever
+    RJMP MAIN           ; Repeat forever
 
 DELAY:
-    LDI R18, 82        ; Outer loop counter
-OUTER:
-    LDI R19, 255       ; Middle loop counter
-MIDDLE:
-    LDI R20, 255       ; Inner loop counter
-INNER:
-    DEC R20            ; 1 cycle
-    BRNE INNER         ; 2 cycles (branch) or 1 cycle (no branch)
-    DEC R19            ; 1 cycle
-    BRNE MIDDLE        ; 2 cycles (branch) or 1 cycle (no branch)
-    DEC R18            ; 1 cycle
-    BRNE OUTER         ; 2 cycles (branch) or 1 cycle (no branch)
-    RET                ; Return from subroutine
+    LDI R18, 82         ; Load outer counter once
+    LDI R19, 255        ; Load middle counter once
+    LDI R20, 255        ; Load inner counter once
+DELAY_LOOP:
+    DEC R20             ; Decrement inner (1 cycle)
+    BRNE DELAY_LOOP     ; Branch if not zero (2 cycles)
+    DEC R19             ; Decrement middle (1 cycle)
+    LDI R20, 255        ; Reload inner counter (1 cycle)
+    BRNE DELAY_LOOP     ; Branch back to inner loop (2 cycles)
+    DEC R18             ; Decrement outer (1 cycle)
+    LDI R19, 255        ; Reload middle counter (1 cycle)
+    BRNE DELAY_LOOP     ; Branch back to middle loop (2 cycles)
+    RET                 ; Return (4 cycles)

--- a/examples/blink.asm
+++ b/examples/blink.asm
@@ -1,22 +1,36 @@
 ; This code is designed for ATmega328 CPUs and can be compiled wit ATmega328Compiler
 
-; Define the LED pin and delay
-LDI R16, 0x20       ; Set R16 to 0x20 (Pin 5, PORTB)
-OUT 0x24, R16       ; Set DDRB to configure Pin 5 as output
+; ATmega328 LED Blink - 1 second on/off
+; Frequency: 16MHz
+; LED: Pin 5 (PORTB)
+; Author: Swen Kalski
 
-LOOP:
-    OUT 0x25, R16   ; Turn LED on (PORTB)
-    CALL DELAY      ; Call delay subroutine
-    OUT 0x25, R0    ; Turn LED off (PORTB)
-    CALL DELAY      ; Call delay subroutine
-    JMP LOOP        ; Repeat the loop
+; Initialize LED pin
+    LDI R16, 0x20       ; Set bit 5 (0b00100000)
+    OUT 0x24, R16       ; DDRB - configure Pin 5 as output
+    CLR R0              ; Clear R0 for LED off state
 
-DELAY:
-    LDI R18, 0xFF   ; Outer loop counter
-    LDI R19, 0xFF   ; Inner loop counter
-DELAY_LOOP:
-    DEC R19         ; Decrement inner loop counter
-    BRNE DELAY_LOOP ; Branch if not zero
-    DEC R18         ; Decrement outer loop counter
-    BRNE DELAY_LOOP ; Branch if not zero
-    RET             ; Return from subroutine
+MAIN_LOOP:
+    OUT 0x25, R16       ; PORTB - LED ON
+    CALL DELAY_1SEC     ; Wait 1 second
+    OUT 0x25, R0        ; PORTB - LED OFF
+    CALL DELAY_1SEC     ; Wait 1 second
+    JMP MAIN_LOOP       ; Repeat forever
+
+DELAY_1SEC:
+    ; At 16MHz, need 16,000,000 cycles for 1 second
+    ; Each inner loop takes 4 cycles
+    ; Each outer loop takes 256 * 4 = 1024 cycles
+    ; Need ~15,625 outer loops for 1 second
+    LDI R18, 0x3D       ; Load 61 (0x3D) for outer loop
+    LDI R19, 0xFF       ; Load 255 for inner loop
+
+DELAY_OUTER:
+    LDI R19, 0xFF       ; Reset inner counter
+DELAY_INNER:
+    NOP                 ; 1 cycle padding
+    DEC R19             ; Decrement inner counter
+    BRNE DELAY_INNER    ; Branch if not zero
+    DEC R18             ; Decrement outer counter
+    BRNE DELAY_OUTER    ; Branch if not zero
+    RET                 ; Return from subroutine

--- a/examples/blink.asm
+++ b/examples/blink.asm
@@ -5,32 +5,25 @@
 ; LED: Pin 5 (PORTB)
 ; Author: Swen Kalski
 
-; Initialize LED pin
     LDI R16, 0x20       ; Set bit 5 (0b00100000)
-    OUT 0x24, R16       ; DDRB - configure Pin 5 as output
-    CLR R0              ; Clear R0 for LED off state
+    OUT 0x24, R16       ; DDRB - set PB5 as output
+    CLR R17             ; Clear R17 for LED off state
 
-MAIN_LOOP:
+LOOP:
     OUT 0x25, R16       ; PORTB - LED ON
-    CALL DELAY_1SEC     ; Wait 1 second
-    OUT 0x25, R0        ; PORTB - LED OFF
-    CALL DELAY_1SEC     ; Wait 1 second
-    JMP MAIN_LOOP       ; Repeat forever
+    RCALL DELAY         ; Wait 1 second
+    OUT 0x25, R17       ; PORTB - LED OFF
+    RCALL DELAY         ; Wait 1 second
+    RJMP LOOP           ; Repeat forever
 
-DELAY_1SEC:
-    ; At 16MHz, need 16,000,000 cycles for 1 second
-    ; Each inner loop takes 4 cycles
-    ; Each outer loop takes 256 * 4 = 1024 cycles
-    ; Need ~15,625 outer loops for 1 second
-    LDI R18, 0x3D       ; Load 61 (0x3D) for outer loop
-    LDI R19, 0xFF       ; Load 255 for inner loop
-
-DELAY_OUTER:
-    LDI R19, 0xFF       ; Reset inner counter
-DELAY_INNER:
-    NOP                 ; 1 cycle padding
-    DEC R19             ; Decrement inner counter
-    BRNE DELAY_INNER    ; Branch if not zero
-    DEC R18             ; Decrement outer counter
-    BRNE DELAY_OUTER    ; Branch if not zero
-    RET                 ; Return from subroutine
+DELAY:                  ; Delay subroutine
+    LDI R20, 82        ; Outer loop counter (82 cycles)
+D1: LDI R21, 255       ; Middle loop counter
+D2: LDI R22, 255       ; Inner loop counter
+D3: DEC R22            ; 1 cycle
+    BRNE D3            ; 2 cycles if branch taken, 1 if not
+    DEC R21            ; 1 cycle
+    BRNE D2            ; 2 cycles if branch taken, 1 if not
+    DEC R20            ; 1 cycle
+    BRNE D1            ; 2 cycles if branch taken, 1 if not
+    RET                ; 4 cycles

--- a/examples/blink.asm
+++ b/examples/blink.asm
@@ -12,3 +12,22 @@
 
 MAIN:
     OUT 0x25, R16       ; PORTB - LED ON
+    RCALL DELAY         ; Wait 1 second
+    OUT 0x25, R17       ; PORTB - LED OFF
+    RCALL DELAY         ; Wait 1 second
+    RJMP MAIN          ; Repeat forever
+
+DELAY:
+    LDI R18, 82        ; Outer loop counter
+OUTER:
+    LDI R19, 255       ; Middle loop counter
+MIDDLE:
+    LDI R20, 255       ; Inner loop counter
+INNER:
+    DEC R20            ; 1 cycle
+    BRNE INNER         ; 2 cycles (branch) or 1 cycle (no branch)
+    DEC R19            ; 1 cycle
+    BRNE MIDDLE        ; 2 cycles (branch) or 1 cycle (no branch)
+    DEC R18            ; 1 cycle
+    BRNE OUTER         ; 2 cycles (branch) or 1 cycle (no branch)
+    RET                ; Return from subroutine

--- a/examples/blink.asm
+++ b/examples/blink.asm
@@ -5,25 +5,32 @@
 ; LED: Pin 5 (PORTB)
 ; Author: Swen Kalski
 
+; Initialize LED pin
     LDI R16, 0x20       ; Set bit 5 (0b00100000)
-    OUT 0x24, R16       ; DDRB - set PB5 as output
-    CLR R17             ; Clear R17 for LED off state
+    OUT 0x24, R16       ; DDRB - configure Pin 5 as output
+    CLR R0              ; Clear R0 for LED off state
 
-LOOP:
+MAIN_LOOP:
     OUT 0x25, R16       ; PORTB - LED ON
-    RCALL DELAY         ; Wait 1 second
-    OUT 0x25, R17       ; PORTB - LED OFF
-    RCALL DELAY         ; Wait 1 second
-    RJMP LOOP           ; Repeat forever
+    CALL DELAY_1SEC     ; Wait 1 second
+    OUT 0x25, R0        ; PORTB - LED OFF
+    CALL DELAY_1SEC     ; Wait 1 second
+    JMP MAIN_LOOP       ; Repeat forever
 
-DELAY:                  ; Delay subroutine
-    LDI R20, 82        ; Outer loop counter (82 cycles)
-D1: LDI R21, 255       ; Middle loop counter
-D2: LDI R22, 255       ; Inner loop counter
-D3: DEC R22            ; 1 cycle
-    BRNE D3            ; 2 cycles if branch taken, 1 if not
-    DEC R21            ; 1 cycle
-    BRNE D2            ; 2 cycles if branch taken, 1 if not
-    DEC R20            ; 1 cycle
-    BRNE D1            ; 2 cycles if branch taken, 1 if not
-    RET                ; 4 cycles
+DELAY_1SEC:
+    ; At 16MHz, need 16,000,000 cycles for 1 second
+    ; Each inner loop takes 4 cycles
+    ; Each outer loop takes 256 * 4 = 1024 cycles
+    ; Need ~15,625 outer loops for 1 second
+    LDI R18, 0x3D       ; Load 61 (0x3D) for outer loop
+    LDI R19, 0xFF       ; Load 255 for inner loop
+
+DELAY_OUTER:
+    LDI R19, 0xFF       ; Reset inner counter
+DELAY_INNER:
+    NOP                 ; 1 cycle padding
+    DEC R19             ; Decrement inner counter
+    BRNE DELAY_INNER    ; Branch if not zero
+    DEC R18             ; Decrement outer counter
+    BRNE DELAY_OUTER    ; Branch if not zero
+    RET                 ; Return from subroutine

--- a/examples/blink.asm
+++ b/examples/blink.asm
@@ -6,31 +6,9 @@
 ; Author: Swen Kalski
 
 ; Initialize LED pin
-    LDI R16, 0x20       ; Set bit 5 (0b00100000)
+     LDI R16, 0x20       ; Set bit 5 (0b00100000)
     OUT 0x24, R16       ; DDRB - configure Pin 5 as output
-    CLR R0              ; Clear R0 for LED off state
+    CLR R17             ; Clear R17 for LED off state
 
-MAIN_LOOP:
+MAIN:
     OUT 0x25, R16       ; PORTB - LED ON
-    CALL DELAY_1SEC     ; Wait 1 second
-    OUT 0x25, R0        ; PORTB - LED OFF
-    CALL DELAY_1SEC     ; Wait 1 second
-    JMP MAIN_LOOP       ; Repeat forever
-
-DELAY_1SEC:
-    ; At 16MHz, need 16,000,000 cycles for 1 second
-    ; Each inner loop takes 4 cycles
-    ; Each outer loop takes 256 * 4 = 1024 cycles
-    ; Need ~15,625 outer loops for 1 second
-    LDI R18, 0x3D       ; Load 61 (0x3D) for outer loop
-    LDI R19, 0xFF       ; Load 255 for inner loop
-
-DELAY_OUTER:
-    LDI R19, 0xFF       ; Reset inner counter
-DELAY_INNER:
-    NOP                 ; 1 cycle padding
-    DEC R19             ; Decrement inner counter
-    BRNE DELAY_INNER    ; Branch if not zero
-    DEC R18             ; Decrement outer counter
-    BRNE DELAY_OUTER    ; Branch if not zero
-    RET                 ; Return from subroutine

--- a/examples/minimal_led_test.asm
+++ b/examples/minimal_led_test.asm
@@ -12,4 +12,6 @@ START:
     OUT 0x25, R16       ; PORTB - LED ON
     CLR R17             ; Clear R17
     OUT 0x25, R17       ; PORTB - LED OFF
-    RET                 ; Return (should halt)
+    RET                 ; Return
+
+; Return causes that the Program restarts - so we have a blinking LED in this case

--- a/examples/minimal_led_test.asm
+++ b/examples/minimal_led_test.asm
@@ -1,0 +1,13 @@
+; This code is designed for ATmega328 CPUs and can be compiled wit ATmega328Compiler
+
+; Minimal LED test for ATmega328
+; LED: Pin 5 (PORTB)
+; Test program counter and execution flow
+; Author: Swen Kalski
+
+    LDI R16, 0x20       ; Set bit 5 (0b00100000)
+    OUT 0x24, R16       ; DDRB - configure Pin 5 as output
+    OUT 0x25, R16       ; PORTB - LED ON
+    CLR R17             ; Clear R17
+    OUT 0x25, R17       ; PORTB - LED OFF
+    JMP 0x0000          ; Jump to start

--- a/examples/minimal_led_test.asm
+++ b/examples/minimal_led_test.asm
@@ -11,4 +11,4 @@ START:
     OUT 0x25, R16       ; PORTB - LED ON
     CLR R17             ; Clear R17
     OUT 0x25, R17       ; PORTB - LED OFF
-    JMP START           ; Jump to start
+    RJMP START          ; Jump to start (relative)

--- a/examples/minimal_led_test.asm
+++ b/examples/minimal_led_test.asm
@@ -5,9 +5,10 @@
 ; Test program counter and execution flow
 ; Author: Swen Kalski
 
+START:
     LDI R16, 0x20       ; Set bit 5 (0b00100000)
     OUT 0x24, R16       ; DDRB - configure Pin 5 as output
     OUT 0x25, R16       ; PORTB - LED ON
     CLR R17             ; Clear R17
     OUT 0x25, R17       ; PORTB - LED OFF
-    JMP 0x0000          ; Jump to start
+    JMP START           ; Jump to start

--- a/examples/minimal_led_test_with_loop.asm
+++ b/examples/minimal_led_test_with_loop.asm
@@ -1,15 +1,18 @@
-; This code is designed for ATmega328 CPUs and can be compiled wit ATmega328Compiler
+ ;This code is designed for ATmega328 CPUs and can be compiled wit ATmega328Compiler
 
 ; Minimal LED test for ATmega328
 ; LED: Pin 5 (PORTB)
 ; Test program counter and execution flow
 ; Author: Swen Kalski
 
-; Minimal LED Test Without Loop
+; Minimal LED Test With Infinite Loop
+
 START:
     LDI R16, 0x20       ; Set bit 5 (0b00100000)
     OUT 0x24, R16       ; DDRB - configure Pin 5 as output
+
+LOOP:
     OUT 0x25, R16       ; PORTB - LED ON
     CLR R17             ; Clear R17
     OUT 0x25, R17       ; PORTB - LED OFF
-    RET                 ; Return (should halt)
+    RJMP LOOP           ; Jump back to LOOP

--- a/src/ATmega328Compiler.cpp
+++ b/src/ATmega328Compiler.cpp
@@ -192,8 +192,24 @@ void ATmega328Compiler::secondPass() {
             }
             int8_t offset = (it->second - address - 1) & 0x7F;
             opcode = 0xF400 | (offset << 3);
+        } else if (mnemonic == "DEC") {
+            // Format: DEC Rd (1001 010d dddd 1010)
+            std::string reg;
+            iss >> reg;
+            int regNum = std::stoi(reg.substr(1));
+            opcode = 0x940A | (regNum << 4);
         }
-        else {
+        else if (mnemonic == "JMP") {
+            // Format: JMP k (1001 010k kkkk 110k kkkk kkkk kkkk kkkk)
+            std::string label;
+            iss >> label;
+            auto it = labelMap.find(label);
+            if (it == labelMap.end()) {
+                throw std::runtime_error("Unknown label: " + label);
+            }
+            uint32_t dest = it->second;
+            opcode = 0x940C | ((dest & 0x1FFFF) << 3);
+        } else {
             auto it = opcodeMap.find(mnemonic);
             if (it == opcodeMap.end()) {
                 throw std::runtime_error("Unknown instruction: " + mnemonic);

--- a/src/ATmega328Compiler.cpp
+++ b/src/ATmega328Compiler.cpp
@@ -143,7 +143,7 @@ void ATmega328Compiler::secondPass() {
             iss >> label;
             auto it = labelMap.find(label);
             if (it == labelMap.end()) {
-                throw std::runtime_error("Unknown label: " + label);
+                throw std::runtime_error("Label not found: " + label);
             }
             opcode = 0x940C | ((it->second & 0x1FFFF) << 3);
         }

--- a/src/ATmega328Compiler.cpp
+++ b/src/ATmega328Compiler.cpp
@@ -73,7 +73,6 @@ void ATmega328Compiler::firstPass() {
         std::istringstream iss(line);
         std::string mnemonic;
         iss >> mnemonic;
-        programCounter += 2;
         // Update PC based on instruction size
         if (mnemonic == "JMP" || mnemonic == "CALL") {
             programCounter += 4;  // 32-bit instructions
@@ -149,7 +148,7 @@ void ATmega328Compiler::secondPass() {
             if (offset < -2048 || offset > 2047) {
                 throw std::runtime_error("RJMP offset out of range");
             }
-            
+            std::cout << "RJMP Offset for Label " << label <<": " << offset << std::endl;
             // Encode offset in instruction
             opcode = 0xC000 | (offset & 0x0FFF);
         }

--- a/src/ATmega328Compiler.cpp
+++ b/src/ATmega328Compiler.cpp
@@ -104,6 +104,17 @@ void ATmega328Compiler::secondPass() {
             int16_t offset = (it->second - address - 1) & 0x0FFF;
             opcode = 0xD000 | offset;
         }
+        else if (mnemonic == "CALL") {
+            // Format: RCALL k (1101 kkkk kkkk kkkk)
+            std::string label;
+            iss >> label;
+            auto it = labelMap.find(label);
+            if (it == labelMap.end()) {
+                throw std::runtime_error("Unknown label: " + label);
+            }
+            int16_t offset = (it->second - address - 1) & 0x0FFF;
+            opcode = 0xD000 | offset;
+        }
         else {
             auto it = opcodeMap.find(mnemonic);
             if (it == opcodeMap.end()) {

--- a/src/ATmega328Compiler.cpp
+++ b/src/ATmega328Compiler.cpp
@@ -127,8 +127,15 @@ void ATmega328Compiler::secondPass() {
             if (it == labelMap.end()) {
                 throw std::runtime_error("Unknown label: " + label);
             }
-            int16_t offset = (it->second - address - 1) & 0x0FFF;
-            opcode = 0xC000 | offset;
+            
+            // Calculate relative offset (-2K to +2K words)
+            int16_t offset = it->second - address - 1;
+            if (offset < -2048 || offset > 2047) {
+                throw std::runtime_error("RJMP offset out of range");
+            }
+            
+            // Encode offset in instruction
+            opcode = 0xC000 | (offset & 0x0FFF);
         }
         else if (mnemonic == "RCALL") {
             // Format: RCALL k (1101 kkkk kkkk kkkk)

--- a/src/ATmega328Compiler.cpp
+++ b/src/ATmega328Compiler.cpp
@@ -73,7 +73,7 @@ void ATmega328Compiler::firstPass() {
         std::istringstream iss(line);
         std::string mnemonic;
         iss >> mnemonic;
-
+        programCounter += 2;
         // Update PC based on instruction size
         if (mnemonic == "JMP" || mnemonic == "CALL") {
             programCounter += 4;  // 32-bit instructions

--- a/src/ATmega328Compiler.hpp
+++ b/src/ATmega328Compiler.hpp
@@ -26,6 +26,8 @@ private:
     void tokenize();
     void firstPass();
     void secondPass();
+    std::string trimOperand(const std::string &operand);
+    int parseRegister(const std::string &reg);
     uint16_t parseOperand(const std::string &operand);
     void writeOutput();
     static std::string trim(const std::string& str);

--- a/src/ATmega328Compiler.hpp
+++ b/src/ATmega328Compiler.hpp
@@ -16,7 +16,10 @@ private:
     std::vector<uint8_t> machineCode;
     std::unordered_map<std::string, uint16_t> opcodeMap;
     std::unordered_map<std::string, size_t> labelMap;
-
+    std::string toHex(uint8_t byte);
+    std::string generateHexRecord(uint16_t address, uint8_t recordType, const std::vector<uint8_t>& data);
+    
+    void writeHexOutput();
     void readFile();
     void tokenize();
     void firstPass();

--- a/src/ATmega328Compiler.hpp
+++ b/src/ATmega328Compiler.hpp
@@ -21,6 +21,7 @@ private:
     std::string generateHexRecord(uint16_t address, uint8_t recordType, const std::vector<uint8_t>& data);
     
     void writeHexOutput();
+    void writeBinOutput();
     void readFile();
     void tokenize();
     void firstPass();

--- a/src/ATmega328Compiler.hpp
+++ b/src/ATmega328Compiler.hpp
@@ -6,10 +6,11 @@
 
 class ATmega328Compiler {
 public:
-    ATmega328Compiler(const std::string& inputFileName, const std::string& outputFileName);
+    ATmega328Compiler(const std::string& cType, const std::string& inputFileName, const std::string& outputFileName);
     void compile();
 
 private:
+    std::string compileType;
     std::string inputFileName;
     std::string outputFileName;
     std::vector<std::string> lines;

--- a/src/OpcodeMap.hpp
+++ b/src/OpcodeMap.hpp
@@ -21,6 +21,7 @@ namespace Opcodes {
         {"BRGE", 0xF404},
         {"BRLT", 0xF400},
         {"DEC", 0x940A},
-        {"CLR", 0x2400}
+        {"CLR", 0x2400},
+        {"RCALL", 0xD000},
     };
 }

--- a/src/OpcodeMap.hpp
+++ b/src/OpcodeMap.hpp
@@ -20,6 +20,7 @@ namespace Opcodes {
         {"BRNE", 0xF401},
         {"BRGE", 0xF404},
         {"BRLT", 0xF400},
-        {"DEC", 0x940A} 
+        {"DEC", 0x940A},
+        {"CLR", 0x2400}
     };
 }

--- a/src/OpcodeMap.hpp
+++ b/src/OpcodeMap.hpp
@@ -23,5 +23,6 @@ namespace Opcodes {
         {"DEC", 0x940A},
         {"CLR", 0x2400},
         {"RCALL", 0xD000},
+        {"RJMP", 0x940C}
     };
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,15 +2,15 @@
 #include <iostream>
 
 int main(int argc, char* argv[]) {
-    if (argc != 3) {
-        std::cerr << "Usage: " << argv[0] << " <input.asm> <output.bin>`\n";
+    if (argc != 4) {
+        std::cerr << "Usage: " << argv[0] << "<hex/bin> <input.asm> <output.bin>`\n";
         return 0;
     }
 
     try {
-        ATmega328Compiler compiler(argv[1], argv[2]);
+        ATmega328Compiler compiler(argv[1], argv[2], argv[3]);
         compiler.compile();
-        std::cout << "Compilation successful. Output written to " << argv[2] << "\n";
+        std::cout << "Compilation successful. Output written to " << argv[3] << "\n";
     } catch (const std::exception& ex) {
         std::cerr << "Error: " << ex.what() << "\n";
         return 1;


### PR DESCRIPTION
As now when jumps or calls happens the whole program segfaults. It might be that the address offset is not calculated correctly. This must be fixed.
Also it is necessary that we can create HEX instead of BIN.
The mix of 32bit (JMP, CALL) should be changed to 16bit (RJMP, RCALL) too.

Fixes:

- [x] fixes handling of opcodes
- [x] fix handling of jump label
- [x] fix creation of bin files
- [x] some minor bug fixes

Features:

- [x] add switch to choose between hex and binary creation

